### PR TITLE
Fix hardcoded /Users/alex path in gitconfig templateDir

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -3,7 +3,7 @@
   cleanup = remote update --prune
   ds  = diff --staged
 [init]
-	templateDir = /Users/alex/.git-templates
+	templateDir = ~/.git-templates
 [user]
 	email = alexraskin@fastmail.fm
 	name = Alex Raskin


### PR DESCRIPTION
Replaces the hardcoded absolute path with ~ so the config works correctly on any machine regardless of the local username.