### PR TITLE
Fix hostname prompt: ask in install.sh, prompt interactively in set-h…

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -117,7 +117,8 @@ fi
 # Hostname (optional)
 read -r -p "Set a custom hostname? [y/N] " set_host
 if [[ "$set_host" =~ ^[Yy]$ ]]; then
-  bash "$HOME/bin/set-hostname.sh"
+  read -r -p "Enter hostname: " new_hostname
+  sudo bash "$HOME/bin/set-hostname.sh" "$new_hostname"
 fi
 
 echo ""

--- a/bin/set-hostname.sh
+++ b/bin/set-hostname.sh
@@ -6,11 +6,10 @@ if [ "$EUID" -ne 0 ]; then
 fi
 
 if [[ -z "$1" ]]; then
-  echo "Usage: $0 <hostname>" >&2
-  exit 1
+  read -r -p "Enter hostname: " new_hostname
+else
+  new_hostname="$1"
 fi
-
-new_hostname="$1"
 echo "Set hostname to '$new_hostname'?"
 select yn in "Yes" "No"; do
   case $yn in


### PR DESCRIPTION
…ostname.sh

install.sh now reads the hostname before calling set-hostname.sh and passes it as an argument. set-hostname.sh falls back to an interactive prompt when run standalone with no argument, instead of exiting with a usage error.

https://claude.ai/code/session_01EdmYYqZ2nyJ2rcAczg6UvV